### PR TITLE
Turn off servo after position is reached

### DIFF
--- a/arduino/chest-opener.ino
+++ b/arduino/chest-opener.ino
@@ -44,7 +44,6 @@ void setup(){
   pinMode(servoPin,OUTPUT);
   pinMode(switchPin,INPUT_PULLUP);
   
-  svo.attach(servoPin); 
 
   MoveChest(false);
   
@@ -59,6 +58,7 @@ void MoveChest(bool open) {
 
   // set the LED:
   digitalWrite(ledPin, open);
+  svo.attach(servoPin); 
 
   if (open) {  
     for (pos = closedPos; pos > openPos; pos--) {
@@ -73,7 +73,10 @@ void MoveChest(bool open) {
       svo.write(pos);              // tell servo to go to position in variable 'pos'
       delay(closeSpeedDelay);                       // waits 15ms for the servo to reach the position
     }  
-  }    
+  }
+
+  delay(250); //shouldn't be necessary since the loop delays should have handled...but we are detaching to being safe
+  svo.detach();   
 }
 
 


### PR DESCRIPTION
Moved the attach and detach method calls to the MoveChest() function. This way the servo is not always on. This change shouldn't be necessary since a RC servo is designed to always be on, but this should lesson power consumption, and maybe extend the life of the servo too.
